### PR TITLE
Update version of pixrem

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "autoprefixer": "^6.0.2",
     "caniuse-api": "^1.3.2",
-    "pixrem": "^2.0.0",
+    "pixrem": "^3.0.0",
     "pleeease-filters": "^2.0.0",
     "postcss": "^5.0.4",
     "postcss-calc": "^5.0.0",


### PR DESCRIPTION
This updates the version of https://github.com/robwierzbowski/node-pixrem in use to `^3.0.0` from `^2.0.0`.

Version 3 moves `rootValue` to an option (https://github.com/robwierzbowski/node-pixrem#options). With Version 2, it's impossible to set `rootValue` through cssnext.